### PR TITLE
Upgrade to node 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:12
 
 # Install pip (https://github.com/aws/aws-cli/issues/2290)
 RUN apt-get update \


### PR DESCRIPTION
Node LTS is now 12.13.0 - we're trying to upgrade the portal and content service, but circleci is still running 10.15 because of this base file.

A straight upgrade like this seems like it'll break other repos still on 10 - could we tag this a specific version and not latest in docker? How can we upgrade safely?